### PR TITLE
Add library publishing

### DIFF
--- a/PCGen-base/build.gradle
+++ b/PCGen-base/build.gradle
@@ -11,6 +11,7 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: "jacoco"
+apply plugin: 'ivy-publish'
 
 group = 'net.sourceforge.pcgen'
 description = """PCGen base library"""
@@ -76,7 +77,43 @@ task echoVer() << {
 jar {
     manifest {
         attributes 'Implementation-Title': 'PCGenBaseLibrary', 'Implementation-Version': project.version, 
-        	'Built-On': buildTimestamp 
+            'Built-On': buildTimestamp 
+    }
+}
+
+task sourceJar(type: Jar) {
+    from sourceSets.main.java
+    classifier "source"
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+// Rules for how we publish our artifacts in ivy compliant format
+publishing {
+    repositories {
+        ivy {
+            name "fileRepo"
+            url '/home/pcgen1/www/librepo'
+            //url 'D:/Projects/pcgen-base/librepo'
+        }
+    }
+    publications {
+        ivy(IvyPublication) {
+            from components.java
+            artifact(sourceJar) {
+                type "source"
+                conf "runtime"
+            }
+            artifact(javadocJar) {
+                type "javadoc"
+            }
+            descriptor.withXml {
+                asNode().info[0].appendNode('description', description)
+            }
+        }
     }
 }
 

--- a/PCGen-base/build.gradle
+++ b/PCGen-base/build.gradle
@@ -70,7 +70,7 @@ allprojects {
 }
 
 task echoVer() << {
-    println "${project.name} Version: ${project.version} ${buildTimestamp}"
+    println "${project.name} Version: ${project.version} (${buildTimestamp})"
 }
 
 jar {


### PR DESCRIPTION
The library is now published to an ivy repository at http://www.pcgen.org/librepo (but there is no file listing) by the Jenkins ci job. See http://www.pcgen.org/librepo/net.sourceforge.pcgen/PCGen-base/1.0.10/ivy-1.0.10.xml for an example.

Once merged the next thing we need to do is set up the push notification for jenkins.